### PR TITLE
Include numeric in byte-mixer.cpp

### DIFF
--- a/src/mixer/byte-mixer.cpp
+++ b/src/mixer/byte-mixer.cpp
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <math.h>
+#include <numeric>
 
 ByteMixer::ByteMixer(const Logistic& logistic, int input_neurons,
     int hidden_neurons, const unsigned int& bit_context, float learning_rate) :


### PR DESCRIPTION
Without that the build fails with:

src/mixer/byte-mixer.cpp: In member function ‘virtual void ByteMixer::ByteUpdate()’:
src/mixer/byte-mixer.cpp:94:50: error: ‘inner_product’ is not a member of ‘std’

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>