### PR TITLE
Explicitly include <vector>

### DIFF
--- a/src/mixer/lstm.h
+++ b/src/mixer/lstm.h
@@ -2,6 +2,7 @@
 #define LSTM_COMPRESS_H
 
 #include <valarray>
+#include <vector>
 #include <memory>
 
 #include "layer.h"


### PR DESCRIPTION
Hi Byron,
There are build errors because of undefined `std::vector` when cmix is compiled using libc++ instead of libstdc++. This PR fixes them.