### PR TITLE
Improvements from paq8px_v102

### DIFF
--- a/src/models/paq8l.cpp
+++ b/src/models/paq8l.cpp
@@ -465,7 +465,7 @@ void train(short *t, short *w, int n, int err) {
 }
 #endif
 
-#define NUM_INPUTS 1261
+#define NUM_INPUTS 1273
 #define NUM_SETS 12
 
 std::vector<float> model_predictions(NUM_INPUTS+NUM_SETS, 0.5);
@@ -626,6 +626,47 @@ inline U8* BH<B>::operator[](U32 i) {
   memmove(&t[(i+1)*B], &t[i*B], j*B);
   memcpy(&t[i*B], tmp, B);
   return &t[i*B+1];
+}
+
+//////////////////////////// HashTable /////////////////////////
+
+// A HashTable maps a 32-bit index to an array of B bytes.
+// The first byte is a checksum using the upper 8 bits of the
+// index.  The second byte is a priority (0 = empty) for hash
+// replacement.  The index need not be a hash.
+
+// HashTable<B> h(n) - create using n bytes  n and B must be
+//     powers of 2 with n >= B*4, and B >= 2.
+// h[i] returns array [1..B-1] of bytes indexed by i, creating and
+//     replacing another element if needed.  Element 0 is the
+//     checksum and should not be modified.
+
+template <int B>
+class HashTable {
+  Array<U8,64> t;  // table: 1 element = B bytes: checksum priority data data
+  const int N;  // size in bytes
+public:
+  HashTable(int n): t(n), N(n) {
+  }
+  U8* operator[](U32 i);
+};
+
+template <int B>
+inline U8* HashTable<B>::operator[](U32 i) {
+  i*=123456791;
+  i=i<<16|i>>16;
+  i*=234567891;
+  int chk=i>>24;
+  i=i*B&(N-B);
+  U8 *p = &t[0];
+  if (p[i]==chk) return p+i;
+  if (p[i^B]==chk) return p+(i^B);
+  if (p[i^B*2]==chk) return p+(i^B*2);
+  if (p[i+1]>p[(i+1)^B] || p[i+1]>p[(i+1)^B*2]) i^=B;
+  if (p[i+1]>p[(i+1)^B^B*2]) i^=B^B*2;
+  memset(p+i, 0, B);
+  p[i]=chk;
+  return p+i;
 }
 
 inline int mix2(Mixer& m, int s, StateMap& sm) {
@@ -864,23 +905,24 @@ U32 b2=0,b3=0,w4=0;
 U32 w5=0,f4=0,tt=0;
 U32 WRT_mpw[16]= { 4, 4, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 };
 U32 WRT_mtt[16]= { 0, 0, 1, 2, 3, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7 };
-int col=0;
+U32 col=0;
 
 static U32 frstchar=0,spafdo=0,spaces=0,spacecount=0, words=0,wordcount=0,wordlen=0,wordlen1=0;
 void wordModel(Mixer& m) {
     static U32 word0=0, word1=0, word2=0, word3=0, word4=0, word5=0;
+    static U32 wrdhsh=0;
     static U32 xword0=0,xword1=0,xword2=0,cword0=0,ccword=0;
     static U32 number0=0, number1=0;
     static U32 text0=0;
-    static U32 lastLetter=0, lastUpper=0, wordGap=0;
-    static ContextMap cm(MEM()*31, 44+1);
+    static U32 lastLetter=0, firstLetter=0, lastUpper=0, lastDigit=0, wordGap=0;
+    static ContextMap cm(MEM()*31, 47);
     static int nl1=-3, nl=-2;
-    static U32 mask = 0;
+    static U32 mask=0, mask2=0;
     static Array<int> wpos(0x10000);
     static int w=0;
 
     if (bpos==0) {
-        int c=c4&255,f=0;
+        int c=c4&255,pC=(U8)c4>>8,f=0;
         if (spaces&0x80000000) --spacecount;
         if (words&0x80000000) --wordcount;
         spaces=spaces*2;
@@ -889,8 +931,18 @@ void wordModel(Mixer& m) {
         lastLetter=min(lastLetter+1,63);
         if (c>='A' && c<='Z') c+='a'-'A';
         if ((c>='a' && c<='z') || c==1 || c==2 ||(c>=128 &&(b2!=3))) {
-            if (!wordlen)
-                wordGap=lastLetter;
+            if (!wordlen){
+                // model syllabification with "+"
+                if ((lastLetter==3 && (c4&0xFFFF00)==0x2B0A00) || (lastLetter==4 && (c4&0xFFFFFF00)==0x2B0D0A00)){
+                    word0 = word1;
+                    wordlen = wordlen1;
+                }
+                else{
+                    wordGap = lastLetter;
+                    firstLetter = c;
+                    wrdhsh = 0;
+                }
+            }
             lastLetter=0;
             ++words, ++wordcount;
             word0^=hash(word0, c,0);
@@ -899,6 +951,16 @@ void wordModel(Mixer& m) {
             wordlen=min(wordlen,45);
             f=0;
             w=word0&(wpos.size()-1);
+            if ((c=='a' || c=='e' || c=='i' || c=='o' || c=='u') || (c=='y' && (wordlen>0 && pC!='a' && pC!='e' && pC!='i' && pC!='o' && pC!='u'))){
+                mask2++;
+                wrdhsh = wrdhsh*997*8+(c/4-22);
+            }
+            else if (c>='b' && c<='z'){
+                mask2+=2;
+                wrdhsh = wrdhsh*271*32+(c-97);
+            }
+            else
+                wrdhsh = wrdhsh*11*32+c;
         }
         else {
             if (word0) {
@@ -919,11 +981,12 @@ void wordModel(Mixer& m) {
             if ((c4&0xFFFF)==0x3D3D) xword1=word1,xword2=word2;
             if ((c4&0xFFFF)==0x2727) xword1=word1,xword2=word2;
             if (c==32 || c==10 ) { ++spaces, ++spacecount; if (c==10 ) nl1=nl, nl=pos-1;}
-            else if (c=='.' || c=='!' || c=='?' || c==',' || c==';' || c==':') spafdo=0,ccword=c;
+            else if (c=='.' || c=='!' || c=='?' || c==',' || c==';' || c==':') spafdo=0,ccword=c,mask2+=3;
             else { ++spafdo; spafdo=min(63,spafdo); }
         }
         if (c>='0' && c<='9') {
             number0^=hash(number0, c,1);
+            lastDigit = 0;
         }
         else if (number0) {
             number1=number0;
@@ -936,14 +999,14 @@ void wordModel(Mixer& m) {
         if (frstchar=='[' && c==32) {if(buf(3)==']' || buf(4)==']' ) frstchar=96,xword0=0;}
         cm.set(hash(513,spafdo, spaces,ccword));
         cm.set(hash(514,frstchar, c));
-        cm.set(hash(515,col, frstchar));
+        cm.set(hash(515,col, frstchar, (lastUpper<col)*4+(mask2&3)));
         cm.set(hash(516,spaces, (words&255)));
 
         cm.set(hash(256,number0, word2));
         cm.set(hash(257,number0, word1));
         cm.set(hash(258,number1, c,ccword));
         cm.set(hash(259,number0, number1));
-        cm.set(hash(260,word0, number1));
+        cm.set(hash(260,word0, number1, lastDigit<wordGap+wordlen));
 
         cm.set(hash(518,wordlen1,col));
         cm.set(hash(519,c,spacecount/2));
@@ -961,7 +1024,7 @@ void wordModel(Mixer& m) {
         cm.set(hash(263,word0, 0));
         cm.set(hash(264,h, word1));
         cm.set(hash(265,word0, word1));
-        cm.set(hash(266,h, word1,word2));
+        cm.set(hash(266,h, word1,word2,lastUpper<wordlen));
         cm.set(hash(268,text0&0xfffff, 0));
           cm.set(hash(269,word0, xword0));
           cm.set(hash(270,word0, xword1));
@@ -1017,6 +1080,8 @@ void wordModel(Mixer& m) {
         ((lastUpper < lastLetter + wordlen1)<<1)|
         (lastUpper < wordlen + wordlen1 + wordGap)
     ));
+    cm.set(hash(col,wordlen1,above&0x5F,c4&0x5F));
+    cm.set(hash( mask2&0x3F, wrdhsh&0xFFF, (0x100|firstLetter)*(wordlen<6),(wordGap>4)*2+(wordlen1>5)) );
     }
     cm.mix(m);
 }
@@ -1106,7 +1171,7 @@ void recordModel(Mixer& m, ModelStats *Stats = NULL) {
   static int rcount[2] = {0,0}; // candidate counts
   static U8 padding = 0; // detected padding byte
   static int prevTransition = 0, col = 0, mxCtx = 0; // position of the last padding transition
-  static ContextMap cm(32768, 3), cn(32768/2, 3), co(32768*2, 3), cp(MEM(), 3+3);
+  static ContextMap cm(32768, 3), cn(32768/2, 3), co(32768*2, 3), cp(MEM(), 6);
 
   if (!bpos) {
     int w=c4&0xffff, c=w&255, d=w>>8;
@@ -1126,19 +1191,20 @@ void recordModel(Mixer& m, ModelStats *Stats = NULL) {
         else rlen[1]=r, rcount[0]=1;
       }
 
-    // check candidate lengths
-    for (int i=0; i < 2; i++) {
-      if (rcount[i] > max(0,12-(int)ilog2(rlen[i+1]))){
-        if (rlen[0] != rlen[i+1]){
-          if ( (rlen[i+1] > rlen[0]) && (rlen[i+1] % rlen[0] == 0) ){
-            // maybe we found a multiple of the real record size..?
-            // in that case, it is probably an immediate multiple (2x).
-            // that is probably more likely the bigger the length, so
-            // check for small lengths too
-            if ((rlen[0] > 32) && (rlen[i+1] == rlen[0]*2)){
-              rcount[0]>>=1;
-              rcount[1]>>=1;
-              continue;
+      // check candidate lengths
+      for (int i=0; i < 2; i++) {
+        if (rcount[i] > max(0,12-(int)ilog2(rlen[i+1]))){
+          if (rlen[0] != rlen[i+1]){
+            if ( (rlen[i+1] > rlen[0]) && (rlen[i+1] % rlen[0] == 0) ){
+              // maybe we found a multiple of the real record size..?
+              // in that case, it is probably an immediate multiple (2x).
+              // that is probably more likely the bigger the length, so
+              // check for small lengths too
+              if ((rlen[0] > 32) && (rlen[i+1] == rlen[0]*2)){
+                rcount[0]>>=1;
+                rcount[1]>>=1;
+                continue;
+              }
             }
             rlen[0] = rlen[i+1];
             rcount[i] = 0;
@@ -1157,6 +1223,7 @@ void recordModel(Mixer& m, ModelStats *Stats = NULL) {
           if (rlen[i+1]<<4 > rlen[1+(i^1)])
             rcount[i^1] = 0;
         }
+      }
     }
 #endif
     cm.set(c<<8| (min(255, pos-cpos1[c])/4) );
@@ -1380,6 +1447,14 @@ inline int i2(int i) {
   return buf(i)+256*buf(i-1);
 }
 
+inline U32 m4(int i) {
+  return buf(i-3)+256*buf(i-2)+65536*buf(i-1)+16777216*buf(i);
+}
+
+inline int m2(int i) {
+  return buf(i)*256+buf(i-1);
+}
+
 inline int sqrbuf(int i) {
   return buf(i)*buf(i);
 }
@@ -1430,7 +1505,68 @@ void im1bitModel(Mixer& m, int w) {
   m.set( (r0&7)|((r1&0x3E)>>2)|((r2&0x1C0)<<2), 2048);
   m.set( y|((r1&0x1C0)>>5)|((r2&0x1C0)>>2)|((r3&0x1C0)<<1), 1024);
   m.set( ((r1>>5)&0xFE)|y, 256);
-  m.set( (r0&0x3)|((r1&0xF80)>>5), 128 );  
+  m.set( (r0&0x3)|((r1&0xF80)>>5), 128 );
+}
+
+//////////////////////////// im4bitModel /////////////////////////////////
+
+// Model for 4-bit image data
+void im4bitModel(Mixer& m, int w) {
+  static HashTable<16> t(MEM()/2);
+  const int S=11; // number of contexts
+  static U8* cp[S];
+  static StateMap sm[S];
+  static U8 WW=0, W=0, NWW=0, NW=0, N=0, NE=0, NEE=0, NNWW = 0, NNW=0, NN=0, NNE=0, NNEE=0;
+  static int col=0, line=0, run=0, prevColor=0, px=0;
+  int i;
+  if (!cp[0]){
+    for (i=0;i<S;i++)
+      cp[i]=t[263*i]+1;
+  }
+  for (i=0;i<S;i++)
+    *cp[i]=nex(*cp[i],y);
+
+  if (!bpos || bpos==4){
+      WW=W, NWW=NW, NW=N, N=NE, NE=NEE, NNWW=NWW, NNW=NN, NN=NNE, NNE=NNEE;
+      if (!bpos)
+        W=c4&0xF, NEE=buf(w-1)>>4, NNEE=buf(w*2-1)>>4;
+      else
+        W=c0&0xF, NEE=buf(w-1)&0xF, NNEE=buf(w*2-1)&0xF;
+      run=(W!=WW || !col)?(prevColor=WW,0):min(0xFFF,run+1);
+      px=1, i=0;
+
+      cp[i++]=t[hash(W,NW,N)]+1;
+      cp[i++]=t[hash(N, min(0xFFF, col/8))]+1;
+      cp[i++]=t[hash(W,NW,N,NN,NE)]+1;
+      cp[i++]=t[hash(W, N, NE+NNE*16, NEE+NNEE*16)]+1;
+      cp[i++]=t[hash(W, N, NW+NNW*16, NWW+NNWW*16)]+1;
+      cp[i++]=t[hash(W, ilog2(run+1), prevColor, col/max(1,w/2) )]+1;
+      cp[i++]=t[hash(NE, min(0x3FF, (col+line)/max(1,w*8)))]+1;
+      cp[i++]=t[hash(NW, (col-line)/max(1,w*8))]+1;
+      cp[i++]=t[hash(WW*16+W,NN*16+N,NNWW*16+NW)]+1;
+      cp[i++]=t[N+NN*16]+1;
+      cp[i++]=t[-1]+1;
+
+      col*=(++col)<w*2;
+      line+=(!col);
+  }
+  else{
+    px+=px+y;
+    int j=(y+1)<<(bpos&3);
+    for (i=0;i<S;i++)
+      cp[i]+=j;
+  }
+
+  // predict
+  for (i=0; i<S; i++)
+    m.add(stretch(sm[i].p(*cp[i])));
+
+  m.set(W*16+px, 256);
+  m.set(min(31,col/max(1,w/16))+N*32, 512);
+  m.set((bpos&3)+4*W+64*min(7,ilog2(run+1)), 512);
+  m.set(W+NE*16+(bpos&3)*256, 1024);
+  m.set(px, 16);
+  m.set(0,1);
 }
 
 void im8bitModel(Mixer& m, int w, int gray = 0) {
@@ -1691,81 +1827,138 @@ void im24bitModel(Mixer& m, int w, int alpha) {
   m.set(c0, 256);
 }
 
+#define CheckIfGrayscale(x,a) {\
+  if (!w && gray && (x%(3+a))==0){\
+      for (int i=0; (i<(3+a)) && gray; i++){\
+        U8 B=buf(4-i);\
+        if (gray>>9){\
+          gray=0x100|B;\
+          pltorder=1-2*(B>0);\
+          if (Stats)\
+            (*Stats).Record = ((*Stats).Record&0xFFFF)|((3+a)<<16);\
+          continue;\
+        }\
+        if (!i){\
+          /* load first component of this entry */ \
+          gray = (gray&(((int)B-(gray&0xFF)==pltorder)<<8));\
+          gray|=(gray)?B:0;\
+        }\
+        else if (i==3)\
+          gray&=((!B || (B==0xFF))*0x1FF); /* alpha/attribute component must be zero or 0xFF */\
+        else\
+          gray&=((B==(gray&0xFF))<<9)-1;\
+      }\
+  }\
+}
+
+struct TGAImage{
+  U32 Header, IdLength, Bpp, ImgType, MapSize, Width, Height;
+};
+struct BMPImage{
+  U32 Header, Offset, Bpp, Size, Palette, HdrLess, Width, Height, BitMask;
+};
+
 int imgModel(Mixer& m, ModelStats *Stats = NULL) {
   static int w=0, bpp=0;
   static int eoi=0;
-  static U32 bmp=0, bmpof=0, bmpw=0, bmph=0, bmpbpp=0, bmps=0, bmpplt=0, hdrless=0, bitmask=0;
+  static BMPImage BMP;
+  static TGAImage TGA;
   static U32 tiff=0;
   static int alpha=0, gray=0, pltorder=0;
- 
+
   if (!bpos){
-    if(pos>=(eoi+40) && !bmp && (
-      (buf(54)=='B' && buf(53)=='M' && ((bmpof=i4(44))&0xFFFFFBF7)==0x36 && i4(40)==0x28) ||
-      (hdrless=(i4(40)==0x28))
+    // detect .BMP/DIB images
+    if (pos>=(eoi+40) && !BMP.Header && (
+       (buf(54)=='B' && buf(53)=='M' && ((BMP.Offset=i4(44))&0xFFFFFBF7)==0x36 && i4(40)==0x28) ||
+       (BMP.HdrLess=(i4(40)==0x28))
     )){
-      bmpw = i4(36);
-      bmph = abs((int)i4(32));
-      bmpbpp = i2(26);
-      bmps = i4(20);
-      bmpplt = i4(4);
-      alpha = (bmpbpp==32);
-            
-      bmp = (i4(24)==0) && (i2(28)==1) && (bmpbpp==1 || bmpbpp==8 || bmpbpp==24 || bmpbpp==32) && bmpw<30000 && bmph<10000 && (!bmpplt || ((U32)(1<<bmpbpp))>=bmpplt);
-      if (bmp){        
-        bpp = bmpbpp;      
-        bmpof = (hdrless)? ((bpp<24)?((bmpplt)?bmpplt*4:4<<bpp):0) :bmpof-54;
-        gray = (bmpbpp==8)?0x300:0;
-        // possible icon/cursor?        
+      BMP.Width = i4(36);
+      BMP.Height = abs((int)i4(32));
+      BMP.Bpp = i2(26);
+      BMP.Size = i4(20);
+      BMP.Palette = i4(4);
+
+      BMP.Header = (i4(24)==0) && (i2(28)==1) && (BMP.Bpp==1 || BMP.Bpp==4 || BMP.Bpp==8 || BMP.Bpp==24 || BMP.Bpp==32) && BMP.Width<30000 && BMP.Height<10000 && (!BMP.Palette || ((U32)(1<<BMP.Bpp))>=BMP.Palette);
+      if (BMP.Header){
+        BMP.Offset = (BMP.HdrLess)? ((BMP.Bpp<24)?((BMP.Palette)?BMP.Palette*4:4<<BMP.Bpp):0):BMP.Offset-54;
+        gray = (BMP.Bpp==8)?0x300:0;
+        // possible icon/cursor?
         // these have a 1bpp AND mask
-        if (hdrless && (bmpw*2==bmph) && bpp>1 &&
+        if (BMP.HdrLess && (BMP.Width*2==BMP.Height) && BMP.Bpp>1 &&
            (
-            (bmps>0 && bmps==( (bmpw*bmph*(bpp+1))>>4 )) ||
-            ((!bmps || bmps<((bmpw*bmph*bpp)>>3)) && (
-              (bmpw==8)   || (bmpw==10) || (bmpw==14) || (bmpw==16) || (bmpw==20) ||
-              (bmpw==22)  || (bmpw==24) || (bmpw==32) || (bmpw==40) || (bmpw==48) ||
-              (bmpw==60)  || (bmpw==64) || (bmpw==72) || (bmpw==80) || (bmpw==96) ||
-              (bmpw==128) || (bmpw==256)
+            (BMP.Size>0 && BMP.Size==( (BMP.Width*BMP.Height*(BMP.Bpp+1))>>4 )) ||
+            ((!BMP.Size || BMP.Size<((BMP.Width*BMP.Height*BMP.Bpp)>>3)) && (
+              (BMP.Width==8)   || (BMP.Width==10) || (BMP.Width==14) || (BMP.Width==16) || (BMP.Width==20) ||
+              (BMP.Width==22)  || (BMP.Width==24) || (BMP.Width==32) || (BMP.Width==40) || (BMP.Width==48) ||
+              (BMP.Width==60)  || (BMP.Width==64) || (BMP.Width==72) || (BMP.Width==80) || (BMP.Width==96) ||
+              (BMP.Width==128) || (BMP.Width==256)
             ))
           )
         )
-          bmph = bitmask = bmpw;
+          BMP.Height = BMP.BitMask = BMP.Width;
       }
     }
     else{
-      bmpof-=(bmpof>0);
-      // process color palette entries
-      if (!w && gray && (bmpof&3)==0){
-          for (int i=0; (i<4) && gray; i++){
-            U8 B=buf(4-i);
-            if (gray>>9){
-              gray=0x100|B;
-              pltorder=1-2*(B>0);
-              if (Stats)
-                (*Stats).Record = ((*Stats).Record&0xFFFF)|(4<<16);
-              continue;
-            }
-            if (!i){
-              // load first component of this entry
-              gray = (gray&(((int)B-(gray&0xFF)==pltorder)<<8)); 
-              gray|=(gray)?B:0;
-            }
-            else if (i==3)
-              gray&=((!B || (B==0xFF))*0x1FF); // alpha/attribute component must be zero or 0xFF
-            else
-              gray&=((B==(gray&0xFF))<<9)-1;
-          }
-      }
+      BMP.Offset-=(BMP.Offset>0);
+      CheckIfGrayscale(BMP.Offset,1);
     }
 
-    if (!bmpof && (bmp>0 || bitmask>0) && pos>=eoi){    
-      if (!bmp && bitmask){
-        bmp=bpp=1;
-        bmpw=bitmask;
-        bitmask=0;
+    if (!BMP.Offset && (BMP.Header>0 || BMP.BitMask>0) && pos>=eoi){
+      if (!BMP.Header && BMP.BitMask){
+        BMP.Header=BMP.Bpp=1;
+        BMP.Width = BMP.BitMask;
+        BMP.BitMask=0;
       }
-      w = (bpp>1)?(bmpw*(bpp>>3)+3)&(-4):(((bmpw-1)>>5)+1)*4;
-      eoi = w*bmph;
-      eoi = (eoi>64)?eoi+pos:(bmp=w=0);
+      bpp = BMP.Bpp;
+      w = (bpp>4)?(BMP.Width*(bpp>>3)+3)&(-4):(bpp==1)?(((BMP.Width-1)>>5)+1)*4:((BMP.Width*4+31)>>5)*4;
+      alpha = (bpp==32);
+      eoi = w*BMP.Height;
+      eoi = (eoi>64)?eoi+pos:(BMP.Header=w=0);
+    }
+
+    // detect .TGA images
+    if (pos>=(eoi+8) && !TGA.Header){
+      if ((m4(8)&0xFFFFFF)==0x010100 && (m4(4)&0xFFFFFFC7)==0x00000100 && (buf(1)==16 || buf(1)==24 || buf(1)==32)){
+        TGA.Header = pos;
+        TGA.IdLength = buf(8);
+        TGA.MapSize = buf(1)/8;
+        TGA.Bpp = 8;
+        TGA.ImgType = 1; // uncompressed color-mapped image
+      }
+      else if ((m4(8)&0xFFFEFF)==0x000200 && !m4(4)){
+        TGA.Header = pos;
+        TGA.IdLength = buf(8);
+        TGA.ImgType = buf(6);
+        TGA.Bpp = (TGA.ImgType==2)?24:8; // Type 2: uncompressed true-color image, no palette / Type 3: uncompressed grayscale image, no palette
+      }
+    }
+    else if (!w && TGA.Header){
+      U32 p = pos - TGA.Header;
+      if (p==8){
+        TGA.Width = i2(4);
+        TGA.Height = i2(2);
+        TGA.Header*=(!i4(8) && TGA.Width && TGA.Width<0x3FFF && TGA.Height && TGA.Height<0x3FFF);
+      }
+      else if (p==10){
+        // 1st byte = BPP
+        // 2nd byte = image spec:
+        //      bits 0 - 3: 0 for 24bpp, 8 for 32bpp (not always)
+        //      bit 5 indicates direction: top-bottom or bottom-top, ignored
+        //      all other bits must be set to 0
+        U16 i = m2(2);
+        if ((i&0xFFF7)==(32<<8))
+          TGA.Bpp = 32;
+        if ((i&0xFFD7)!=(TGA.Bpp<<8))
+          memset(&TGA, 0, sizeof(TGAImage));
+      }
+      if (TGA.Header && p==10 + TGA.IdLength + TGA.MapSize*256){
+        w = (TGA.Width*TGA.Bpp)>>3;
+        gray = (TGA.ImgType==3);
+        bpp = TGA.Bpp;
+        alpha = (bpp==32);
+        eoi = w*TGA.Height;
+        eoi = (eoi>64)?eoi+pos:(TGA.Header=w=0);
+      }
     }
   }
 
@@ -1797,17 +1990,19 @@ int imgModel(Mixer& m, ModelStats *Stats = NULL) {
     }
   }
   if (pos>eoi) return w=0;
-  
   if (w){
     switch (bpp){
-      case 1 : im1bitModel(m, w); break;      
+      case 1 : im1bitModel(m, w); break;
+      case 4 : im4bitModel(m, w); break;
       case 8 : im8bitModel(m, w, gray); break;
       default: im24bitModel(m, w, alpha);
     }
   }
-  if (bpos==7 && (pos+1)==eoi)
-      bmp=gray=tiff=alpha=0;
-  
+  if (bpos==7 && (pos+1)==eoi){
+    memset(&TGA, 0, sizeof(TGAImage));
+    BMP.Header=gray=tiff=alpha=0;
+  }
+
   return w;
 }
 


### PR DESCRIPTION
- Improved x86/x64 model
- 1bpp image model
- Improved BMP/DIB detection:
 - Now handles 1bpp images, and compresses the 1bpp AND mask that follows most icons
 - Can now process the color palette entries to determine if the 8bpp image is grayscale, and signals the record model when processing them, so it can adjust the record length accordingly