### PR TITLE
Performance improvement

### DIFF
--- a/src/mixer/lstm-layer.cpp
+++ b/src/mixer/lstm-layer.cpp
@@ -6,17 +6,116 @@
 #include <algorithm>
 #include <numeric>
 
+#ifdef __AVX2__
+#include <immintrin.h>
+
+namespace {
+
+inline float HorizontalSum(__m256 v) {
+  __m128 hi = _mm256_extractf128_ps(v, 1);
+  __m128 lo = _mm256_castps256_ps128(v);
+  lo = _mm_add_ps(lo, hi);
+  hi = _mm_movehl_ps(hi, lo);
+  lo = _mm_add_ps(lo, hi);
+  hi = _mm_shuffle_ps(lo, lo, 1);
+  lo = _mm_add_ss(lo, hi);
+  return _mm_cvtss_f32(lo);
+}
+
+inline float AvxDotProduct(const float* a, const float* b, int n) {
+  __m256 sum = _mm256_setzero_ps();
+  int i = 0;
+  for (; i + 7 < n; i += 8) {
+    __m256 va = _mm256_loadu_ps(a + i);
+    __m256 vb = _mm256_loadu_ps(b + i);
+    sum = _mm256_fmadd_ps(va, vb, sum);
+  }
+  float result = HorizontalSum(sum);
+  for (; i < n; ++i) {
+    result += a[i] * b[i];
+  }
+  return result;
+}
+
+void Adam(std::valarray<float>* g, std::valarray<float>* m,
+    std::valarray<float>* v, std::valarray<float>* w, float learning_rate,
+    float t, unsigned long long update_limit) {
+  const float beta1 = 0.025f, beta2 = 0.9999f, eps = 1e-6f;
+  float alpha;
+  if (t < update_limit) {
+    alpha = learning_rate * 0.1f / sqrt(5e-5f * t + 1.0f);
+  } else {
+    alpha = learning_rate * 0.1f / sqrt(5e-5f * update_limit + 1.0f);
+  }
+
+  float bias_m, bias_v_corr;
+  if (t < update_limit) {
+    bias_m = 1.0f / (1.0f - pow(beta1, t));
+    bias_v_corr = 1.0f / (1.0f - pow(beta2, t));
+  } else {
+    bias_m = 1.0f / (1.0f - pow(beta1, update_limit));
+    bias_v_corr = 1.0f / (1.0f - pow(beta2, update_limit));
+  }
+
+  int n = g->size();
+  float* gp = &(*g)[0];
+  float* mp = &(*m)[0];
+  float* vp = &(*v)[0];
+  float* wp = &(*w)[0];
+
+  __m256 vbeta1 = _mm256_set1_ps(beta1);
+  __m256 v1mbeta1 = _mm256_set1_ps(1.0f - beta1);
+  __m256 vbeta2 = _mm256_set1_ps(beta2);
+  __m256 v1mbeta2 = _mm256_set1_ps(1.0f - beta2);
+  __m256 valpha = _mm256_set1_ps(alpha);
+  __m256 vbias_m = _mm256_set1_ps(bias_m);
+  __m256 vbias_v = _mm256_set1_ps(bias_v_corr);
+  __m256 veps = _mm256_set1_ps(eps);
+
+  int i = 0;
+  for (; i + 7 < n; i += 8) {
+    __m256 vg = _mm256_loadu_ps(gp + i);
+    __m256 vm = _mm256_loadu_ps(mp + i);
+    __m256 vv = _mm256_loadu_ps(vp + i);
+    __m256 vw = _mm256_loadu_ps(wp + i);
+
+    // m = m * beta1 + (1 - beta1) * g
+    vm = _mm256_fmadd_ps(vm, vbeta1, _mm256_mul_ps(v1mbeta1, vg));
+    // v = v * beta2 + (1 - beta2) * g * g
+    vv = _mm256_fmadd_ps(vv, vbeta2, _mm256_mul_ps(v1mbeta2, _mm256_mul_ps(vg, vg)));
+    // w -= alpha * (m * bias_m) / sqrt(v * bias_v + eps)
+    __m256 m_hat = _mm256_mul_ps(vm, vbias_m);
+    __m256 v_hat = _mm256_fmadd_ps(vv, vbias_v, veps);
+    __m256 update = _mm256_mul_ps(valpha, _mm256_div_ps(m_hat, _mm256_sqrt_ps(v_hat)));
+    vw = _mm256_sub_ps(vw, update);
+
+    _mm256_storeu_ps(mp + i, vm);
+    _mm256_storeu_ps(vp + i, vv);
+    _mm256_storeu_ps(wp + i, vw);
+  }
+  // Scalar tail
+  for (; i < n; ++i) {
+    mp[i] = mp[i] * beta1 + (1.0f - beta1) * gp[i];
+    vp[i] = vp[i] * beta2 + (1.0f - beta2) * gp[i] * gp[i];
+    wp[i] -= alpha * (mp[i] * bias_m) / sqrt(vp[i] * bias_v_corr + eps);
+  }
+}
+
+}  // namespace
+
+#else
+
 namespace {
 
 void Adam(std::valarray<float>* g, std::valarray<float>* m,
     std::valarray<float>* v, std::valarray<float>* w, float learning_rate,
     float t, unsigned long long update_limit) {
-  const float beta1 = 0.025, beta2 = 0.9999, eps = 1e-6f; 
+  const float beta1 = 0.025, beta2 = 0.9999, eps = 1e-6f;
   float alpha;
   if (t < update_limit) {
-    alpha = learning_rate * 0.1f / sqrt(5e-5f * t + 1.0f); 
+    alpha = learning_rate * 0.1f / sqrt(5e-5f * t + 1.0f);
   } else {
-    alpha = learning_rate * 0.1f / sqrt(5e-5f * update_limit + 1.0f); 
+    alpha = learning_rate * 0.1f / sqrt(5e-5f * update_limit + 1.0f);
   }
   (*m) *= beta1;
   (*m) += (1.0f - beta1) * (*g);
@@ -31,7 +130,8 @@ void Adam(std::valarray<float>* g, std::valarray<float>* m,
   }
 }
 
-}
+}  // namespace
+#endif
 
 LstmLayer::LstmLayer(unsigned int input_size, unsigned int auxiliary_input_size,
     unsigned int output_size, unsigned int num_cells, int horizon,
@@ -84,6 +184,16 @@ void LstmLayer::ForwardPass(const std::valarray<float>& input, int input_symbol,
 
 void LstmLayer::ForwardPass(NeuronLayer& neurons,
     const std::valarray<float>& input, int input_symbol) {
+#ifdef __AVX2__
+  int input_n = input.size();
+  const float* input_ptr = &input[0];
+  for (unsigned int i = 0; i < num_cells_; ++i) {
+    float f = neurons.weights_[i][input_symbol];
+    const float* w_ptr = &neurons.weights_[i][output_size_];
+    f += AvxDotProduct(input_ptr, w_ptr, input_n);
+    neurons.norm_[epoch_][i] = f;
+  }
+#else
   for (unsigned int i = 0; i < num_cells_; ++i) {
     float f = neurons.weights_[i][input_symbol];
     for (unsigned int j = 0; j < input.size(); ++j) {
@@ -91,6 +201,7 @@ void LstmLayer::ForwardPass(NeuronLayer& neurons,
     }
     neurons.norm_[epoch_][i] = f;
   }
+#endif
   neurons.ivar_[epoch_] = 1.0f / sqrt(((neurons.norm_[epoch_] *
       neurons.norm_[epoch_]).sum() / num_cells_) + 1e-5f);
   neurons.norm_[epoch_] *= neurons.ivar_[epoch_];
@@ -161,6 +272,24 @@ void LstmLayer::BackwardPass(NeuronLayer& neurons,
   neurons.error_ *= neurons.gamma_ * neurons.ivar_[epoch];
   neurons.error_ -= ((neurons.error_ * neurons.norm_[epoch]).sum() /
       num_cells_) * neurons.norm_[epoch];
+
+#ifdef __AVX2__
+  const float* err_ptr = &neurons.error_[0];
+  int nc = num_cells_;
+
+  if (layer > 0) {
+    for (unsigned int i = 0; i < num_cells_; ++i) {
+      const float* t_ptr = &neurons.transpose_[num_cells_ + i][0];
+      (*hidden_error)[i] += AvxDotProduct(err_ptr, t_ptr, nc);
+    }
+  }
+  if (epoch > 0) {
+    for (unsigned int i = 0; i < num_cells_; ++i) {
+      const float* t_ptr = &neurons.transpose_[i][0];
+      stored_error_[i] += AvxDotProduct(err_ptr, t_ptr, nc);
+    }
+  }
+#else
   if (layer > 0) {
     for (unsigned int i = 0; i < num_cells_; ++i) {
       float f = 0;
@@ -179,6 +308,8 @@ void LstmLayer::BackwardPass(NeuronLayer& neurons,
       stored_error_[i] += f;
     }
   }
+#endif
+
   std::slice slice = std::slice(output_size_, input.size(), 1);
   for (unsigned int i = 0; i < num_cells_; ++i) {
     neurons.update_[i][slice] += neurons.error_[i] * input;

--- a/src/mixer/lstm.cpp
+++ b/src/mixer/lstm.cpp
@@ -5,6 +5,71 @@
 #include <fstream>
 #include <iostream>
 
+#ifdef __AVX2__
+#include <immintrin.h>
+
+namespace {
+
+inline float HorizontalSum(__m256 v) {
+  __m128 hi = _mm256_extractf128_ps(v, 1);
+  __m128 lo = _mm256_castps256_ps128(v);
+  lo = _mm_add_ps(lo, hi);
+  hi = _mm_movehl_ps(hi, lo);
+  lo = _mm_add_ps(lo, hi);
+  hi = _mm_shuffle_ps(lo, lo, 1);
+  lo = _mm_add_ss(lo, hi);
+  return _mm_cvtss_f32(lo);
+}
+
+inline float AvxDotProduct(const float* a, const float* b, int n) {
+  __m256 sum = _mm256_setzero_ps();
+  int i = 0;
+  for (; i + 7 < n; i += 8) {
+    __m256 va = _mm256_loadu_ps(a + i);
+    __m256 vb = _mm256_loadu_ps(b + i);
+    sum = _mm256_fmadd_ps(va, vb, sum);
+  }
+  float result = HorizontalSum(sum);
+  for (; i < n; ++i) {
+    result += a[i] * b[i];
+  }
+  return result;
+}
+
+// dst[i] += src[i] * scalar
+inline void AvxScaledAdd(float* dst, const float* src, float scalar, int n) {
+  __m256 vs = _mm256_set1_ps(scalar);
+  int i = 0;
+  for (; i + 7 < n; i += 8) {
+    __m256 vd = _mm256_loadu_ps(dst + i);
+    __m256 vsrc = _mm256_loadu_ps(src + i);
+    vd = _mm256_fmadd_ps(vsrc, vs, vd);
+    _mm256_storeu_ps(dst + i, vd);
+  }
+  for (; i < n; ++i) {
+    dst[i] += src[i] * scalar;
+  }
+}
+
+// dst = src; dst -= scalar * mul
+inline void AvxCopyAndScaledSub(float* dst, const float* src, const float* mul,
+    float scalar, int n) {
+  __m256 vs = _mm256_set1_ps(scalar);
+  int i = 0;
+  for (; i + 7 < n; i += 8) {
+    __m256 vsrc = _mm256_loadu_ps(src + i);
+    __m256 vmul = _mm256_loadu_ps(mul + i);
+    vsrc = _mm256_fnmadd_ps(vs, vmul, vsrc);
+    _mm256_storeu_ps(dst + i, vsrc);
+  }
+  for (; i < n; ++i) {
+    dst[i] = src[i] - scalar * mul[i];
+  }
+}
+
+}  // namespace
+#endif
+
 Lstm::Lstm(unsigned int input_size, unsigned int output_size, unsigned int
     num_cells, unsigned int num_layers, int horizon, float learning_rate,
     float gradient_clip) : input_history_(horizon),
@@ -93,12 +158,22 @@ std::valarray<float>& Lstm::Perceive(unsigned int input) {
     for (int epoch = horizon_ - 1; epoch >= 0; --epoch) {
       for (int layer = layers_.size() - 1; layer >= 0; --layer) {
         int offset = layer * num_cells_;
+#ifdef __AVX2__
+        int hn = hidden_error_.size();
+        for (unsigned int i = 0; i < output_size_; ++i) {
+          float error = (i == input_history_[epoch]) ?
+              (output_[epoch][i] - 1) : output_[epoch][i];
+          AvxScaledAdd(&hidden_error_[0],
+              &output_layer_[epoch][i][offset], error, hn);
+        }
+#else
         for (unsigned int i = 0; i < output_size_; ++i) {
           float error = (i == input_history_[epoch]) ? (output_[epoch][i] - 1) : output_[epoch][i];
           for (unsigned int j = 0; j < hidden_error_.size(); ++j) {
             hidden_error_[j] += output_layer_[epoch][i][j + offset] * error;
           }
         }
+#endif
         int prev_epoch = epoch - 1;
         if (prev_epoch == -1) prev_epoch = horizon_ - 1;
         int input_symbol = input_history_[prev_epoch];
@@ -109,11 +184,21 @@ std::valarray<float>& Lstm::Perceive(unsigned int input) {
     }
   }
 
+#ifdef __AVX2__
+  int hn = hidden_.size();
+  for (unsigned int i = 0; i < output_size_; ++i) {
+    float error = (i == input) ? (output_[last_epoch][i] - 1) : output_[last_epoch][i];
+    float lr_error = learning_rate_ * error;
+    AvxCopyAndScaledSub(&output_layer_[epoch_][i][0],
+        &output_layer_[last_epoch][i][0], &hidden_[0], lr_error, hn);
+  }
+#else
   for (unsigned int i = 0; i < output_size_; ++i) {
     float error = (i == input) ? (output_[last_epoch][i] - 1) : output_[last_epoch][i];
     output_layer_[epoch_][i] = output_layer_[last_epoch][i];
     output_layer_[epoch_][i] -= learning_rate_ * error * hidden_;
   }
+#endif
   return Predict(input);
 }
 
@@ -130,6 +215,17 @@ std::valarray<float>& Lstm::Predict(unsigned int input) {
       std::copy(start, start + num_cells_, start2);
     }
   }
+
+#ifdef __AVX2__
+  int hn = hidden_.size();
+  const float* hp = &hidden_[0];
+  float max_out = 0;
+  for (unsigned int i = 0; i < output_size_; ++i) {
+    float sum = AvxDotProduct(hp, &output_layer_[epoch_][i][0], hn);
+    output_[epoch_][i] = sum;
+    max_out = std::max(sum, max_out);
+  }
+#else
   float max_out = 0;
   for (unsigned int i = 0; i < output_size_; ++i) {
     float sum = 0;
@@ -139,6 +235,8 @@ std::valarray<float>& Lstm::Predict(unsigned int input) {
     output_[epoch_][i] = sum;
     max_out = std::max(sum, max_out);
   }
+#endif
+
   for (unsigned int i = 0; i < output_size_; ++i) {
     output_[epoch_][i] = exp(output_[epoch_][i] - max_out);
   }

--- a/src/mixer/mixer.cpp
+++ b/src/mixer/mixer.cpp
@@ -5,6 +5,70 @@
 #include <numeric>
 #include <math.h>
 
+#ifdef __AVX2__
+#include <immintrin.h>
+
+namespace {
+
+inline float HorizontalSum(__m256 v) {
+  __m128 hi = _mm256_extractf128_ps(v, 1);
+  __m128 lo = _mm256_castps256_ps128(v);
+  lo = _mm_add_ps(lo, hi);
+  hi = _mm_movehl_ps(hi, lo);
+  lo = _mm_add_ps(lo, hi);
+  hi = _mm_shuffle_ps(lo, lo, 1);
+  lo = _mm_add_ss(lo, hi);
+  return _mm_cvtss_f32(lo);
+}
+
+inline float AvxDotProduct(const float* a, const float* b, int n) {
+  __m256 sum = _mm256_setzero_ps();
+  int i = 0;
+  for (; i + 7 < n; i += 8) {
+    __m256 va = _mm256_loadu_ps(a + i);
+    __m256 vb = _mm256_loadu_ps(b + i);
+    sum = _mm256_fmadd_ps(va, vb, sum);
+  }
+  float result = HorizontalSum(sum);
+  for (; i < n; ++i) {
+    result += a[i] * b[i];
+  }
+  return result;
+}
+
+// weights -= update * inputs
+inline void AvxWeightUpdate(float* weights, const float* inputs, float update,
+    int n) {
+  __m256 vupdate = _mm256_set1_ps(update);
+  int i = 0;
+  for (; i + 7 < n; i += 8) {
+    __m256 vw = _mm256_loadu_ps(weights + i);
+    __m256 vi = _mm256_loadu_ps(inputs + i);
+    vw = _mm256_fnmadd_ps(vupdate, vi, vw);
+    _mm256_storeu_ps(weights + i, vw);
+  }
+  for (; i < n; ++i) {
+    weights[i] -= update * inputs[i];
+  }
+}
+
+// weights *= scale
+inline void AvxScale(float* weights, float scale, int n) {
+  __m256 vs = _mm256_set1_ps(scale);
+  int i = 0;
+  for (; i + 7 < n; i += 8) {
+    __m256 vw = _mm256_loadu_ps(weights + i);
+    vw = _mm256_mul_ps(vw, vs);
+    _mm256_storeu_ps(weights + i, vw);
+  }
+  for (; i < n; ++i) {
+    weights[i] *= scale;
+  }
+}
+
+}  // namespace
+#endif
+
 Mixer::Mixer(const std::valarray<float>& inputs,
     const std::vector<float>& extra_inputs,
     const unsigned long long& context, float learning_rate,
@@ -37,19 +101,35 @@ ContextData* Mixer::GetContextData() {
 
 float Mixer::Mix() {
   ContextData* data = GetContextData();
+
+#ifdef __AVX2__
+  int n = inputs_.size();
+  p_ = AvxDotProduct(&inputs_[0], &data->weights[0], n);
+#else
   float p = 0;
   for (int i = 0; i < inputs_.size(); ++i) {
     p += inputs_[i] * data->weights[i];
   }
   p_ = p;
+#endif
+
   for (unsigned int i = 0; i < extra_inputs_.size(); ++i) {
     extra_inputs_[i] = extra_inputs_vec_[i];
   }
+
+#ifdef __AVX2__
+  int ne = extra_inputs_.size();
+  if (ne > 0) {
+    p_ += AvxDotProduct(&extra_inputs_[0], &data->extra_weights[0], ne);
+  }
+#else
   float e = 0;
   for (unsigned int i = 0; i < extra_inputs_.size(); ++i) {
     e += extra_inputs_[i] * data->extra_weights[i];
   }
   p_ += e;
+#endif
+
   return p_;
 }
 
@@ -63,10 +143,28 @@ void Mixer::Perceive(int bit) {
   if (data->steps > max_steps_) {
     max_steps_ = data->steps;
   }
+
+#ifdef __AVX2__
+  int n = inputs_.size();
+  AvxWeightUpdate(&data->weights[0], &inputs_[0], update, n);
+
+  int ne = extra_inputs_.size();
+  if (ne > 0) {
+    AvxWeightUpdate(&data->extra_weights[0], &extra_inputs_[0], update, ne);
+  }
+
+  if ((data->steps & 1023) == 0) {
+    AvxScale(&data->weights[0], 1.0f - 3.0e-6f, n);
+    if (ne > 0) {
+      AvxScale(&data->extra_weights[0], 1.0f - 3.0e-6f, ne);
+    }
+  }
+#else
   data->weights -= update * inputs_;
   data->extra_weights -= update * extra_inputs_;
   if ((data->steps & 1023) == 0) {
     data->weights *= 1.0f - 3.0e-6f;
     data->extra_weights *= 1.0f - 3.0e-6f;
   }
+#endif
 }


### PR DESCRIPTION
Added AVX2-accelerated dot products, weight updates, and Adam optimizer across lstm.cpp, lstm-layer.cpp, and mixer.cpp. All changes are behind #ifdef __AVX2__ with the original scalar code as fallback, so non-AVX2 systems are unaffected.

Note: I did use AI (claude) for this since i'm not an expert at c++ coding. The performance gain is pretty high (78s to 46s for a 31kB png file), so might as well make a PR.