### PR TITLE
Preserve line endings in english.dic and new_article_order

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Set the default behavior for all files. All other settings below will overwrite this default.
+* text=auto
+
+# These files must stay intact.
+english.dic binary
+new_article_order binary
+
+# Normalized and converts to native line endings on checkout.
+*.cpp text
+*.hpp text
+*.c   text
+*.h   text
+
+# Convert to CRLF line endings on checkout.
+*.sln text eol=crlf
+*.cmd text eol=crlf
+
+# Convert to LF line endings on checkout.
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vs/
 /data/
 /scripts/
 /cmix


### PR DESCRIPTION
When cloning the repository on Windows, git silently modifies the dictionary file and the article order file to have CRLF line endings. The english.dic file should be 411996 bytes, but on Windows it becomes 456511 bytes - similarly with the new_article_order (1094862 vs 1267139 bytes).