### PR TITLE
Build fixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 CXX = clang++-17
 LFLAGS = -std=c++14 -Wall
 
-all: LFLAGS += -Ofast -march=native
+all: LFLAGS += -Ofast -march=native -DNDEBUG
 all: cmix enwik9-preproc remap
 
 debug: LFLAGS += -ggdb

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,11 @@ project('cmix', 'cpp',
 # compiler setup
 cpp = meson.get_compiler('cpp')
 
+# Add NDEBUG for non-debug builds (release, minsize, etc.)
+if get_option('buildtype') != 'debug'
+  add_project_arguments('-DNDEBUG', language: 'cpp')
+endif
+
 # base compiler flags
 base_args = []
 

--- a/src/models/byte-model.cpp
+++ b/src/models/byte-model.cpp
@@ -7,8 +7,9 @@ ByteModel::ByteModel(const std::vector<bool>& vocab) : ex(0),top_(255), mid_(0),
 
 const std::valarray<float>& ByteModel::Predict() {
   auto mid = bot_ + ((top_ - bot_) / 2);
-  float num = std::accumulate(&probs_[mid + 1], &probs_[top_ + 1], 0.0f);
-  float denom = std::accumulate(&probs_[bot_], &probs_[mid + 1], num);
+  const float* base = &probs_[0];
+  float num = std::accumulate(base + mid + 1, base + top_ + 1, 0.0f);
+  float denom = std::accumulate(base + bot_, base + mid + 1, num);
   ex = bot_;
     float max_prob_val = probs_[bot_];
     for (int i = bot_ + 1; i <= top_; i++) {

--- a/src/models/fxcmv1.cpp
+++ b/src/models/fxcmv1.cpp
@@ -28,7 +28,6 @@
 #include <algorithm>
 #include <unordered_map>
 #include <memory>
-#define NDEBUG  // remove for debugging (turns on Array bound checks)
 #include <assert.h>
 
 typedef unsigned char U8;

--- a/src/models/model.h
+++ b/src/models/model.h
@@ -1,6 +1,7 @@
 #ifndef MODEL_H
 #define MODEL_H
 
+#include <cstdint>
 #include <valarray>
 
 class Model {

--- a/src/models/paq8.cpp
+++ b/src/models/paq8.cpp
@@ -29,7 +29,6 @@
 #include <ctype.h>
 #include <unordered_map>
 #include <memory>
-#define NDEBUG
 
 #ifdef UNIX
 #include <sys/types.h>


### PR DESCRIPTION
- Prevent valarray from incorrectly reporting out-of-bounds access (with asserts on) in byte-model's Predict()
- Fix building on some platforms (missing cstdint include)
- Remove file-wise NDEBUG defines (conflicted with global settings); add global NDEBUG to Makefile and meson.build instead.