### PR TITLE
Fixed uninitialized variable issue in ppmd model.

### DIFF
--- a/src/models/ppmd.cpp
+++ b/src/models/ppmd.cpp
@@ -730,7 +730,7 @@ PPM_CONTEXT* UpdateModel( PPM_CONTEXT* MinContext ) {
   byte Flag, FSymbol;
   uint ns1, ns, cf, sf, s0, FFreq;
   uint iSuccessor, iFSuccessor;
-  PPM_CONTEXT* pc;
+  PPM_CONTEXT* pc = NULL;
   STATE* p = NULL;
 
   FSymbol = FoundState->Symbol;
@@ -756,7 +756,7 @@ PPM_CONTEXT* UpdateModel( PPM_CONTEXT* MinContext ) {
       p[0].Freq += (p[0].Freq<14);
     }
   }
-  // pc = MaxContext;
+  pc = MaxContext;
 
   if( !OrderFall && iFSuccessor ) {
     FoundState->iSuccessor = CreateSuccessors( 1, p, MinContext );


### PR DESCRIPTION
Visual Studio detected the issue (error while building with SDLCheck = true).

Confirmed by running enwik6 with low a memory setting in debug mode and got an uninitialized variable access exception here:

if( pText>=UnitsStart ) { saved_pc=pc; return 0; };